### PR TITLE
fix: update default domain to bytebuzz.dev

### DIFF
--- a/src/lib/analytics/domain-check.ts
+++ b/src/lib/analytics/domain-check.ts
@@ -1,4 +1,4 @@
-const HOST_NAME = process.env.VERCEL_PROJECT_PRODUCTION_URL || "localhost";
+const HOST_NAME = process.env.VERCEL_PROJECT_PRODUCTION_URL || "bytebuzz.dev";
 
 export function isDomainAllowed({ userAgent, url }: { userAgent: string; url: string }) {
   return !userAgent?.includes("vercel") && url.includes(HOST_NAME);


### PR DESCRIPTION
## Describe your changes
Update the default domain from 'localhost' to 'bytebuzz.dev' in the domain check analytics configuration.

### Include a screenshot where applicable

## Issue ticket number and link

