### PR TITLE
fix(sidebar): replace Iconify with direct lucide-react imports for better SSR

### DIFF
--- a/src/components/sidebar/sidebar-account-dropdown.tsx
+++ b/src/components/sidebar/sidebar-account-dropdown.tsx
@@ -65,6 +65,7 @@ export function SidebarAccountDropdown({ isActive, label }: SidebarAccountDropdo
           </Button>
 
           <Button
+            as={"div"}
             className="w-full justify-start mt-1"
             variant="light"
             startContent={<SunMoonIcon size={18} />}

--- a/src/components/sidebar/sidebar-theme-switcher.tsx
+++ b/src/components/sidebar/sidebar-theme-switcher.tsx
@@ -1,11 +1,8 @@
-import { ButtonGroup } from "@heroui/react";
-import { Icon } from "@iconify/react";
-import { useTheme } from "next-themes";
-import dynamic from "next/dynamic";
+"use client";
 
-const Button = dynamic(() => import("@heroui/react").then((mod) => mod.Button), {
-  ssr: false,
-});
+import { Button, ButtonGroup } from "@heroui/react";
+import { LaptopIcon, MoonIcon, SunIcon } from "lucide-react";
+import { useTheme } from "next-themes";
 
 export function SidebarThemeSwitcher() {
   const { theme, setTheme } = useTheme();
@@ -17,21 +14,21 @@ export function SidebarThemeSwitcher() {
         color={theme === "light" ? "primary" : "default"}
         onPress={() => setTheme("light")}
       >
-        <Icon icon="lucide:sun" width={16} height={16} />
+        <SunIcon size={16} />
       </Button>
       <Button
         isIconOnly
         color={theme === "system" ? "primary" : "default"}
         onPress={() => setTheme("system")}
       >
-        <Icon icon="lucide:laptop" width={16} height={16} />
+        <LaptopIcon size={16} />
       </Button>
       <Button
         isIconOnly
         color={theme === "dark" ? "primary" : "default"}
         onPress={() => setTheme("dark")}
       >
-        <Icon icon="lucide:moon" width={16} height={16} />
+        <MoonIcon size={16} />
       </Button>
     </ButtonGroup>
   );


### PR DESCRIPTION
## Describe your changes

This PR replaces Iconify icons with direct lucide-react imports in the sidebar components to improve Server-Side Rendering (SSR) performance and compatibility.

### Key Changes:

- **SidebarThemeSwitcher**: Replaced `<Icon icon="lucide:..." />` with direct imports (`<SunIcon />`, `<LaptopIcon />`, `<MoonIcon />`)
- **Removed dynamic imports**: Eliminated the `dynamic()` wrapper around Button component that was disabling SSR
- **Added "use client"**: Ensured proper client-side rendering directive
- **Updated imports**: Changed from `@iconify/react` to `lucide-react` for better tree-shaking and SSR compatibility

### Benefits:

- ✅ Better SSR compatibility and hydration consistency
- ✅ Reduced bundle size through tree-shaking
- ✅ Faster initial render times
- ✅ Improved type safety
- ✅ Elimination of potential flash of unstyled icons

### Include a screenshot where applicable

_No visual changes - icons remain identical in appearance_

## Issue ticket number and link

Closes #17
