### PR TITLE
refactor: rename isModal prop to isNavigationDisabled for better clarity

### DIFF
--- a/src/components/post/post-card-footer.tsx
+++ b/src/components/post/post-card-footer.tsx
@@ -20,7 +20,7 @@ const reactions: Reaction[] = [
 ];
 
 export function PostFooter() {
-  const { isThreadPagePost, togglePostModal, post, isModal } = usePostContext();
+  const { isThreadPagePost, togglePostModal, post, isNavigationDisabled } = usePostContext();
   const [selectedReaction, setSelectedReaction] = useState<Reaction["type"] | null>(
     post.reaction?.reaction_type ?? null,
   );
@@ -55,7 +55,7 @@ export function PostFooter() {
   return (
     <>
       <CardFooter className={cn("z-30 flex flex-col gap-1 w-full")}>
-        {!isModal && (
+        {!isNavigationDisabled && (
           <>
             {/* Legend: All reactions ordered + total counter */}
             {sortedReactions.length > 0 && (

--- a/src/components/post/post-card.tsx
+++ b/src/components/post/post-card.tsx
@@ -13,14 +13,14 @@ interface PostCardProps {
 }
 
 export function PostCard({ children, className, classNames, ref }: PostCardProps) {
-  const { isThreadPagePost, post, isModal } = usePostContext();
+  const { isThreadPagePost, post, isNavigationDisabled } = usePostContext();
   const router = useRouter();
   const pathname = usePathname();
 
   function handleClick(event: React.MouseEvent<HTMLDivElement>) {
     // Check if the clicked element or its parents is an anchor tag
     const isAnchorElement = (event.target as HTMLElement).closest("a");
-    if (isAnchorElement || isModal) return;
+    if (isAnchorElement || isNavigationDisabled) return;
 
     const pushPath = `/@${post.user?.username}/thread/${post.id}`;
 
@@ -33,7 +33,7 @@ export function PostCard({ children, className, classNames, ref }: PostCardProps
         className={cn(
           "relative flex flex-row dark:bg-content1 bg-[transparent] [box-shadow:none]",
           {
-            "cursor-pointer": !isModal,
+            "cursor-pointer": !isNavigationDisabled,
           },
           className,
         )}

--- a/src/components/post/user-post.tsx
+++ b/src/components/post/user-post.tsx
@@ -13,7 +13,7 @@ interface UserPostProps {
   isLastInThread?: boolean;
   ref?: React.RefObject<HTMLDivElement>;
   className?: string;
-  isModal?: boolean;
+  isNavigationDisabled?: boolean;
 }
 
 export function UserPost({
@@ -24,7 +24,7 @@ export function UserPost({
   isLastInThread,
   ref,
   className,
-  isModal,
+  isNavigationDisabled,
 }: UserPostProps) {
   if (!post && !ancestry) {
     throw new Error("Either post or ancestry must be provided");
@@ -47,7 +47,7 @@ export function UserPost({
           isThread={renderAsThread}
           isFirstInThread={firstInThread}
           isLastInThread={lastInThread}
-          isModal={isModal}
+          isNavigationDisabled={isNavigationDisabled}
         >
           <PostCard ref={ref} className={className}>
             <PostHeader />

--- a/src/components/reply-to-post.tsx
+++ b/src/components/reply-to-post.tsx
@@ -12,7 +12,7 @@ export function ReplyToPost({ post, onSubmit = () => Promise.resolve() }: ReplyT
   return (
     <div className="relative flex flex-col gap-2">
       <PostThreadLine isFirstInThread={true} isLastInThread={true} />
-      <UserPost post={post} isModal />
+      <UserPost post={post} isNavigationDisabled />
       <PostComposer
         placeholder={`Reply to @${post.user?.username}`}
         onSubmit={onSubmit}

--- a/src/context/post-provider.tsx
+++ b/src/context/post-provider.tsx
@@ -10,7 +10,11 @@ export interface PostContextType {
   isThread?: boolean;
   isFirstInThread?: boolean;
   isLastInThread?: boolean;
-  isModal?: boolean;
+  /**
+   * When true, disables click-to-navigate interaction on the post.
+   * Used when the post is displayed in a modal context where navigation should be prevented.
+   */
+  isNavigationDisabled?: boolean;
 
   /**
    * Indicates if this post is the main post being viewed in a thread page.
@@ -26,7 +30,7 @@ export const PostContext = createContext<PostContextType>({} as PostContextType)
 export interface PostProviderProps {
   children: React.ReactNode;
   post: NestedPost;
-  isModal?: boolean;
+  isNavigationDisabled?: boolean;
   isThread?: boolean;
   isFirstInThread?: boolean;
   isLastInThread?: boolean;
@@ -34,7 +38,7 @@ export interface PostProviderProps {
 
 export function PostProvider({
   children,
-  isModal = false,
+  isNavigationDisabled = false,
   post,
   isThread,
   isFirstInThread,
@@ -53,11 +57,11 @@ export function PostProvider({
     <PostContext.Provider
       value={{
         post,
-        isModal,
+        isNavigationDisabled,
         isThread,
         isFirstInThread,
         isLastInThread,
-        isThreadPagePost: !isModal && post.id === postId,
+        isThreadPagePost: !isNavigationDisabled && post.id === postId,
         togglePostModal,
       }}
     >


### PR DESCRIPTION
## Describe your changes

This PR renames the `isModal` prop to `isNavigationDisabled` across several components to better reflect its purpose. The prop is used to disable click-to-navigate interaction on posts when they are displayed in contexts where navigation should be prevented (like modals).

Changes include:

- Renamed `isModal` prop to `isNavigationDisabled` in PostProvider and related components
- Added JSDoc documentation to clarify the prop's purpose
- Updated all component implementations to use the new prop name
- No functional changes, only improved naming for better code clarity

### Include a screenshot where applicable

N/A - This is a refactoring change that doesn't affect the UI.

## Issue ticket number and link

N/A
