### PR TITLE
feat(markdown): enhance image grid layout and improve viewer components

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,12 @@ const nextConfig: NextConfig = {
       {
         hostname: "github.com",
       },
+      {
+        hostname: "localhost",
+      },
+      {
+        hostname: "bytebuzz.dev",
+      },
     ],
   },
 };

--- a/src/actions/upload-post-media.ts
+++ b/src/actions/upload-post-media.ts
@@ -3,6 +3,10 @@
 import { createServerSupabaseClient } from "@/db/supabase";
 import { currentUser } from "@clerk/nextjs/server";
 
+const DOMAIN = process.env.VERCEL_URL
+  ? `https://${process.env.VERCEL_URL}`
+  : process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+
 /**
  * Uploads a media file to Supabase storage in a temporary location
  * @param file - The file to upload
@@ -46,7 +50,7 @@ export async function uploadPostMediaAction(
     } = supabase.storage.from("post-images").getPublicUrl(filePath);
 
     // Instead of getting the Supabase URL, return our proxied URL
-    const proxyUrl = `http://localhost:3000/api/media/${userId}/${fileNameWithoutExtension}`;
+    const proxyUrl = `${DOMAIN}/api/media/${userId}/${fileNameWithoutExtension}`;
 
     return {
       publicUrl,

--- a/src/components/markdown-viewer/markdown-viewer.tsx
+++ b/src/components/markdown-viewer/markdown-viewer.tsx
@@ -1,39 +1,101 @@
 "use client";
 
 import { CodeBlock } from "@/components/ui/code-block";
-import { Image } from "@heroui/react";
+import Image from "next/image";
+import type { ReactElement } from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import type { ComponentPropsWithoutRef } from "react";
+import { cn } from "@/lib/utils";
+
+type ReactElementWithNode = ReactElement & { props: { node: { tagName: string } } };
+
+type MarkdownImageProps = ComponentPropsWithoutRef<"img">;
 
 export function MarkdownViewer({ markdown, postId }: { markdown: string; postId: string }) {
+  // Extract image count from markdown by counting ![] patterns
+  const imageCount = (markdown.match(/!\[.*?\]\(.*?\)/g) || []).length;
+
   return (
-    <Markdown
-      remarkPlugins={[remarkGfm]}
-      components={{
-        code: ({ node, ...props }) => {
-          const { children, className } = props;
-          const language = className?.replace("language-", "");
-          return <CodeBlock code={children as string} language={language} />;
-        },
-        img: ({ node, ...props }) => {
-          const { src, alt, ...rest } = props;
+    <>
+      <Markdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          p: ({ node, ...props }) => {
+            const { children, className } = props;
 
-          // Append postId as a query parameter
-          const imageUrl = `${src}?postId=${postId}`;
+            const isChildImage = (children as ReactElementWithNode)?.props?.node?.tagName === "img";
+            if (isChildImage) return <>{children}</>;
 
-          return (
-            <Image
-              className="rounded-medium"
-              src={imageUrl}
-              alt={alt}
-              {...rest}
-              onError={() => {}}
-            />
-          );
-        },
-      }}
-    >
-      {markdown}
-    </Markdown>
+            if (!children) return null;
+
+            return <p className={className}>{children}</p>;
+          },
+          code: ({ node, ...props }) => {
+            const { children, className } = props;
+            const language = className?.replace("language-", "");
+            return <CodeBlock code={children as string} language={language} />;
+          },
+        }}
+        disallowedElements={["img"]}
+      >
+        {markdown}
+      </Markdown>
+      {imageCount > 0 && (
+        <div
+          className={cn(
+            "rounded-medium aspect-video border dark:border-content2 border-content3 overflow-hidden grid",
+            {
+              "grid-cols-2": imageCount === 2,
+              "grid-cols-2 grid-rows-2": imageCount === 3 || imageCount >= 4,
+            },
+            imageCount === 3 && [
+              "[&_>:nth-child(1)]:[grid-area:1/1/3/2]",
+              "[&_>:nth-child(2)]:[grid-area:1/2/2/3]",
+              "[&_>:nth-child(3)]:[grid-area:2/2/3/3]",
+            ],
+          )}
+        >
+          <Markdown
+            remarkPlugins={[remarkGfm]}
+            components={{
+              p: ({ node, ...props }) => {
+                const { children } = props;
+
+                const isChildImage =
+                  (children as ReactElementWithNode)?.props?.node?.tagName === "img";
+                if (isChildImage) return <>{children}</>;
+
+                return null;
+              },
+              img: (props: MarkdownImageProps) => {
+                const { src, alt } = props;
+                const imageUrl = `${src}?postId=${postId}`;
+
+                return (
+                  <div
+                    className={cn(
+                      "relative outline-[0.5px] dark:outline-content2 outline-content3",
+                    )}
+                  >
+                    <Image
+                      className="h-full"
+                      src={imageUrl}
+                      alt={alt || "Image"}
+                      fill
+                      objectFit="cover"
+                      unoptimized
+                    />
+                  </div>
+                );
+              },
+            }}
+            allowedElements={["img", "p"]}
+          >
+            {markdown}
+          </Markdown>
+        </div>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
## Describe your changes

This PR enhances the markdown viewer component with improved image handling and layout features:

Key changes:

- Implemented a responsive image grid layout that adapts to the number of images (1-4 images)
- Switched from @heroui/react Image to next/image for better optimization
- Added support for localhost and bytebuzz.dev image domains in next.config.ts
- Improved markdown rendering with better paragraph and image handling
- Enhanced image display with proper aspect ratios and border styling

## Issue ticket number and link
