### PR TITLE
fix: add explicit permissions to GitHub Actions release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
       - develop
       - main
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   version_pr:
     if: github.ref == 'refs/heads/develop'


### PR DESCRIPTION
## Describe your changes

This PR adds explicit permissions to the GitHub Actions release workflow to ensure it has the necessary access to write contents and pull requests. This is a security best practice that follows the principle of least privilege by explicitly defining the permissions needed for the workflow to function properly.

The changes include:
- Added `contents: write` permission to allow the workflow to create releases and tags
- Added `pull-requests: write` permission to allow the workflow to create and update pull requests

### Include a screenshot where applicable

No screenshot applicable for this infrastructure change.

## Issue ticket number and link

No related issue found.
