### PR TITLE
refactor: update GitHub Actions release workflow to use GitHub CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
       - develop
       - main
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   version_pr:
     if: github.ref == 'refs/heads/develop'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,15 +29,36 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      - name: Create/Update Version PR
-        uses: changesets/action@v1
-        with:
-          version: bun run release:version
-          commit: "Version Packages"
-          title: "Version Packages"
-          setupGitUser: true
+      - name: Create/Update Version PR using GitHub CLI
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch --all --tags
+
+          # Run Changesets versioning; this updates package versions and changelogs if changesets exist
+          bun run release:version || true
+
+          # If no changes produced by versioning, exit gracefully
+          if git diff --quiet && git diff --staged --quiet; then
+            echo "No changesets to version. Skipping PR creation."
+            exit 0
+          fi
+
+          BRANCH="changeset/release-${GITHUB_REF_NAME}"
+          git checkout -B "$BRANCH"
+          git add -A
+          git commit -m "chore: version packages"
+          git push --force --set-upstream origin "$BRANCH"
+
+          # Create or update the PR targeting develop
+          if gh pr view --head "$BRANCH" >/dev/null 2>&1; then
+            gh pr edit --head "$BRANCH" --title "Version Packages" --body "Automated version bump and changelog." --base develop
+          else
+            gh pr create --title "Version Packages" --body "Automated version bump and changelog." --base develop --head "$BRANCH"
+          fi
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish_release:
     if: github.ref == 'refs/heads/main'
@@ -56,11 +77,26 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      - name: Tag and Create GitHub Release
-        uses: changesets/action@v1
-        with:
-          publish: bun run release:tag
-          setupGitUser: true
-          createGithubReleases: true
+      - name: Tag and Create GitHub Release using GitHub CLI
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch --all --tags
+
+          # Create and push tag from current version in package.json
+          VERSION="v$(jq -r .version package.json)"
+          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+            echo "Tag $VERSION already exists. Skipping tag creation."
+          else
+            bun run release:tag
+          fi
+
+          # Create GitHub Release if it doesn't exist
+          if gh release view "$VERSION" >/dev/null 2>&1; then
+            echo "Release $VERSION already exists."
+          else
+            gh release create "$VERSION" --generate-notes
+          fi
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Describe your changes

This PR refactors the GitHub Actions release workflow to use GitHub CLI directly instead of the changesets action. The changes include:

- **Version PR Creation**: Replaced `changesets/action@v1` with custom GitHub CLI commands for creating version PRs
- **Release Publishing**: Updated the publish workflow to use GitHub CLI for tagging and creating releases
- **Improved Error Handling**: Added proper error handling and conditional logic to prevent duplicate tags/releases
- **Better Git Configuration**: Explicitly configured git user for GitHub Actions bot

The workflow now has more control over the release process and better handles edge cases like existing tags and releases.

### Include a screenshot where applicable

N/A - Infrastructure changes only

## Issue ticket number and link

No matching issue found
